### PR TITLE
Feature/hide progress on complete

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -12,6 +12,11 @@ android {
         versionName "1.0"
     }
     buildTypes {
+
+        debug {
+            minifyEnabled false
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -67,6 +67,7 @@
         app:fbb_progressWidthRatio="0.1"
         app:fbb_endBitmap="@drawable/ic_fab_complete"
         app:fbb_showEndBitmap="true"
+        app:fbb_hideProgressOnComplete="true"
         />
 
     <Button

--- a/fabbutton/src/main/java/mbanje/kurt/fabbutton/CircleImageView.java
+++ b/fabbutton/src/main/java/mbanje/kurt/fabbutton/CircleImageView.java
@@ -37,14 +37,11 @@ import android.graphics.Paint;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 
 
 public class CircleImageView extends ImageView {
-
-    private static final String TAG = CircleImageView.class.getSimpleName();
 
     public interface OnFabViewListener {
         public void onProgressVisibilityChanged(boolean visible);
@@ -223,7 +220,7 @@ public class CircleImageView extends ImageView {
     /**
      * this animates between the icon set in the imageview and the completed icon. does as crossfade animation
      * @param show set flag
-     * @param hideOnComplete
+     * @param hideOnComplete if true animate outside ring out after progress complete
      */
     public void showCompleted(boolean show, boolean hideOnComplete){
         if(show){

--- a/fabbutton/src/main/java/mbanje/kurt/fabbutton/CircleImageView.java
+++ b/fabbutton/src/main/java/mbanje/kurt/fabbutton/CircleImageView.java
@@ -37,11 +37,14 @@ import android.graphics.Paint;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 
 
 public class CircleImageView extends ImageView {
+
+    private static final String TAG = CircleImageView.class.getSimpleName();
 
     public interface OnFabViewListener {
         public void onProgressVisibilityChanged(boolean visible);
@@ -179,6 +182,7 @@ public class CircleImageView extends ImageView {
         ringWidth = Math.round((float) viewRadius * ringWidthRatio);
         circleRadius = viewRadius - ringWidth;
         ringPaint.setStrokeWidth(ringWidth);
+        ringPaint.setAlpha(ringAlpha);
         ringRadius = circleRadius - ringWidth/2;
     }
 
@@ -219,10 +223,18 @@ public class CircleImageView extends ImageView {
     /**
      * this animates between the icon set in the imageview and the completed icon. does as crossfade animation
      * @param show set flag
+     * @param hideOnComplete
      */
-    public void showCompleted(boolean show){
+    public void showCompleted(boolean show, boolean hideOnComplete){
         if(show){
             crossfader.startTransition(500);
+        }
+        if (hideOnComplete) {
+            ObjectAnimator hideAnimator = ObjectAnimator.ofFloat(this, "currentRingWidth", 0f, 0f);
+            hideAnimator.setFloatValues(1);
+            hideAnimator.setDuration(animationDuration);
+            hideAnimator.start();
+
         }
     }
 }

--- a/fabbutton/src/main/java/mbanje/kurt/fabbutton/FabButton.java
+++ b/fabbutton/src/main/java/mbanje/kurt/fabbutton/FabButton.java
@@ -44,6 +44,7 @@ public class FabButton extends FrameLayout implements CircleImageView.OnFabViewL
     private boolean autostartanim;
     private int endBitmapResource;
     private boolean showEndBitmap;
+    private boolean hideProgressOnComplete;
 
     public FabButton(Context context) {
         super(context);
@@ -85,6 +86,7 @@ public class FabButton extends FrameLayout implements CircleImageView.OnFabViewL
             ringWidthRatio = a.getFloat(R.styleable.CircleImageView_fbb_progressWidthRatio, ringWidthRatio);
             endBitmapResource = a.getResourceId(R.styleable.CircleImageView_fbb_endBitmap, R.drawable.ic_fab_complete);
             showEndBitmap = a.getBoolean(R.styleable.CircleImageView_fbb_showEndBitmap,false);
+            hideProgressOnComplete = a.getBoolean(R.styleable.CircleImageView_fbb_hideProgressOnComplete, false);
 
             a.recycle();
         }
@@ -132,11 +134,11 @@ public class FabButton extends FrameLayout implements CircleImageView.OnFabViewL
      * @param show shows animation ring when set to true
      */
     public void showProgress(boolean show){
-        if(show){
-            circle.showRing(true);
-        }else{
-            circle.showRing(false);
-        }
+        circle.showRing(show);
+    }
+
+    public void hideProgressOnComplete(boolean hide) {
+        hideProgressOnComplete = hide;
     }
 
     public void setEnabled(boolean enabled) {
@@ -166,6 +168,9 @@ public class FabButton extends FrameLayout implements CircleImageView.OnFabViewL
 
     @Override
     public void onProgressCompleted() {
-        circle.showCompleted(showEndBitmap);
+        circle.showCompleted(showEndBitmap, hideProgressOnComplete);
+        if (hideProgressOnComplete) {
+            ring.setVisibility(View.GONE);
+        }
     }
 }

--- a/fabbutton/src/main/res/values/attrs.xml
+++ b/fabbutton/src/main/res/values/attrs.xml
@@ -37,5 +37,6 @@
         <attr name="fbb_progressWidthRatio" format="float" />
         <attr name="fbb_endBitmap" format="reference" />
         <attr name="fbb_showEndBitmap" format="boolean" />
+        <attr name="fbb_hideProgressOnComplete" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Added **Hide Progress on Complete** feature: ring disappear after progress is completed.

This can be enabled with code or xml attribute:

* `fabButton.hideProgressOnComplete(true);`
* `app:fbb_hideProgressOnComplete="true"`

![progress-hide](https://cloud.githubusercontent.com/assets/354372/7100544/baff2638-e020-11e4-94bb-f30d8ca5c078.gif)
